### PR TITLE
Add donation instructions

### DIFF
--- a/sps20/content/helpus/contents.lr
+++ b/sps20/content/helpus/contents.lr
@@ -61,4 +61,4 @@ Association.
    href="https://donorbox.org/donate-to-the-swiss-python-association">Donate</a>
 
 If you wish to donate via bank transfer, the Swiss Python Summit Association's
-IBAN is CH79 0900 0000 8984 1185 1.
+IBAN is CH79 0900 0000 8984 1185 1 (Recipient: `Swiss Python Summit Association, 8000 Zürich`).


### PR DESCRIPTION
This adds a donation button and pop-up form from Donorbox. It also adds our IBAN in case people prefer to transfer money directly.