### PR TITLE
Fix talk titles and speaker names on talk recordings page

### DIFF
--- a/sps20/content/talk-recordings/contents.lr
+++ b/sps20/content/talk-recordings/contents.lr
@@ -15,14 +15,14 @@ Here you can find recorded talks of the last summits. The presentation slides ar
 
 Please find the slides already below. We are currently working on this year's recodings..
 
-- **Proving Python code correct with nagini [[slides](sps23_marco_eilers_proving_python_code_correct_with_nagini.pdf)]**<br>marco eilers
-- **Did you know Matplotlib could do that [[slides](sps23_teresa_kubacka_did_you_know_matplotlib_could_do_that.pdf)]**<br>teresa kubacka
-- **Kivy cross-platform app development for pythonistas [[slides](sps23_mirko_galimberti_kivy_cross-platform_app_development_for_pythonistas.pdf)]**<br>mirko galimberti
-- **A walk with Cpython [[slides](sps23_sadhana_srinivasan_a_walk_with_cpython.pdf)]**<br>sadhana srinivasan
+- **Proving Python code correct with Nagini [[slides](sps23_marco_eilers_proving_python_code_correct_with_nagini.pdf)]**<br>Marco Eilers
+- **Did you know Matplotlib could do that? [[slides](sps23_teresa_kubacka_did_you_know_matplotlib_could_do_that.pdf)]**<br>Teresa Kubacka
+- **Kivy: Cross-platform App development for Pythonistas [[slides](sps23_mirko_galimberti_kivy_cross-platform_app_development_for_pythonistas.pdf)]**<br>Mirko Galimberti
+- **A walk with CPython [[slides](sps23_sadhana_srinivasan_a_walk_with_cpython.pdf)]**<br>Sadhana Srinivasan
 - **Documenting Python Code [[slides (extern)](https://link.simplexacode.ch/jwh6)]**<br>Christian Heitzmann
-- **A short history of python web frameworks [[slides](sps23_nafiul_islam_a_short_history_of_python_web_frameworks.pdf)]**<br>nafiul islam
-- **Voice control python for operating a quadrupedal robot [[slides](sps23_robin_ehrensperger_voice_control_python_for_operating_a_quadrupedal_robot.pdf)]**<br>robin ehrensperger
-- **Asynchronous multiprocess large model training on Pytorch [[slides](sps23_pavel_sulimov_asynchronous_multiprocess_large_model_training_on_pytorch.pdf)]**<br>pavel sulimov
+- **Voice Control in Action: A Python-Based Approach for Operating a Quadrupedal Robot [[slides](sps23_robin_ehrensperger_voice_control_python_for_operating_a_quadrupedal_robot.pdf)]**<br>Robin Ehrensperger
+- **A Short History of Python Web Frameworks [[slides](sps23_nafiul_islam_a_short_history_of_python_web_frameworks.pdf)]**<br>Quazi Nafiul Islam
+- **Asynchronous Multiprocess Large Model Training on PyTorch for Synthetic Cities Generation [[slides](sps23_pavel_sulimov_asynchronous_multiprocess_large_model_training_on_pytorch.pdf)]**<br>Pavel Sulimov
 
 ---
 _template: recordings.html


### PR DESCRIPTION
I fixed the talk titles and order to match https://www.python-summit.ch/program/ and used capitalization for the names.