### PR TITLE
Add custom 404 page

### DIFF
--- a/sps20/content/404.html/contents.lr
+++ b/sps20/content/404.html/contents.lr
@@ -1,0 +1,11 @@
+title: Oops!
+---
+ordering: -1
+---
+body:
+
+The page you are looking for does not exist.
+
+Want to go back to the [homepage](/)?
+---
+_template: 404.html

--- a/sps20/sps20.lektorproject
+++ b/sps20/sps20.lektorproject
@@ -5,3 +5,6 @@ name = Swiss Python Summit 2022
 lektor-scss = 1.3.3
 lektor-markdown-admonition = 0.3.1
 lektor-markdown-header-anchors = 0.3.1
+
+[error_handlers]
+404 = /404.html

--- a/sps20/templates/404.html
+++ b/sps20/templates/404.html
@@ -1,0 +1,6 @@
+{% extends "layout.html" %}
+
+{% block body %}
+    <h2>{{ this.title }}</h2>
+    <p>{{ this.body }}</p>
+{% endblock %}

--- a/sps20/templates/layout.html
+++ b/sps20/templates/layout.html
@@ -23,7 +23,9 @@
                         <a href="{{ site.root|url }}" class="btn btn-link {{ site.root == this and 'active' or ''}}">Swiss Python Summit</a>
 
                         {% for page in site.root.children | sort(attribute="ordering") %}
-                        <a href="{{ page|url }}" class="btn btn-link {{ page == this and 'active' or ''}}">{{ page.title }}</a>
+                            {% if page.ordering > 0 %}
+                                <a href="{{ page|url }}" class="btn btn-link {{ page == this and 'active' or ''}}">{{ page.title }}</a>
+                            {% endif %}
                         {% endfor %}
                     </section>
                 </header>


### PR DESCRIPTION
Add a custom 404 page.

It has an ordering of -1 to exclude it from the tab. The tab links are now only created for orderings greater than 0 (since venue starts with 1). But this logic could be changed if needed.