### PR TITLE
Add redirects from wrong link to pretalx schedule

### DIFF
--- a/sps20/content/swiss-python-summit-2024/contents.lr
+++ b/sps20/content/swiss-python-summit-2024/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: https://pretalx.sifs0005.infs.ch/swiss-python-summit-2024
+---
+_discoverable: no

--- a/sps20/content/swiss-python-summit-2024/schedule/contents.lr
+++ b/sps20/content/swiss-python-summit-2024/schedule/contents.lr
@@ -1,0 +1,5 @@
+_model: redirect
+---
+target: https://pretalx.sifs0005.infs.ch/swiss-python-summit-2024/schedule
+---
+_discoverable: no

--- a/sps20/models/redirect.ini
+++ b/sps20/models/redirect.ini
@@ -1,0 +1,7 @@
+[model]
+name = Redirect
+
+[fields.target]
+label = Redirect Target
+type = string
+description = Target is of type 'string' to allow relative paths. Converted to url in the template.

--- a/sps20/templates/redirect.html
+++ b/sps20/templates/redirect.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; URL='{{ this.target|url }}'" />


### PR DESCRIPTION
The redirects don't fully work in the preview app, because of the netlify hot-reloading script which seems to interfer. 