### PR TITLE
Fix preloading of hero and logo images

### DIFF
--- a/sps20/templates/layout.html
+++ b/sps20/templates/layout.html
@@ -7,8 +7,8 @@
         <meta name="theme-color" content="#85495d">
 
         <link rel="stylesheet" href="{{ '/css/style.css'|url }}">
-        <link rel="preload" href="hero.webp" as="image">
-        <link rel="preload" href="logo.svg" as="image">
+        <link rel="preload" href="/hero.webp" as="image">
+        <link rel="preload" href="/logo.svg" as="image">
 
         <title>{% block title %}Welcome{% endblock %} — Swiss Python Summit</title>
     </head>

--- a/sps20/templates/layout.html
+++ b/sps20/templates/layout.html
@@ -7,7 +7,7 @@
         <meta name="theme-color" content="#85495d">
 
         <link rel="stylesheet" href="{{ '/css/style.css'|url }}">
-        <link rel="preload" href="hero.jpg" as="image">
+        <link rel="preload" href="hero.webp" as="image">
         <link rel="preload" href="logo.svg" as="image">
 
         <title>{% block title %}Welcome{% endblock %} — Swiss Python Summit</title>


### PR DESCRIPTION
In aefed2e5a7476d51ae5685a1b40b1a9d649f96ef the hero image was switched from jpg to webp buth the pre-loading wasn't fixed.