### PR TITLE
Reorder sponsor perks

### DIFF
--- a/sps20/content/sponsoring/contents.lr
+++ b/sps20/content/sponsoring/contents.lr
@@ -19,17 +19,17 @@ Sponsorship benefits are outlined below. Here are some key facts:
 | Price (CHF)                               | 3000 | 1500   | 500    |
 | Total available                           |  1   | 2      | 4      |
 | Still available                           |  0   | 1      | 2      |
-| Sponsoring for both days                  |  ✔  | ✔     | ✔     |
+| Sponsoring for both days                  |  ✔   | ✔      | ✔      |
 | Two-day tickets included                  |  5   | 3      | 2      |
-| Logo on Website  					  		|  ✔ (<small>big</small>)   | ✔ (<small>medium</small>)      | ✔ (<small>small</small>)     |
-| Logo on break slides                      |  ✔  | ✔     | ✔     |
-| Customized break slide	                |  ✔  |        |        |
-| Credits on social media                   |  ✔  |        |        |
-| Shoutout on LinkedIn before summit		|  ✔ (<small>200 words, image</small>)  |   ✔ (<small>50 words</small>)     |        |
-| Shoutout on LinkedIn after summit		    |  ✔  | ✔     | ✔     |
-| Company merch            					|  ✔  | ✔     |      |
-| Table space            					|  big  | small     |  none    |
-| Wall or info roll-up   					|  ✔  | ✔     |      |      |
+| Logo on Website                           |  ✔ (<small>big</small>) | ✔ (<small>medium</small>) | ✔ (<small>small</small>) |
+| Logo on break slides                      |  ✔   | ✔      | ✔      |
+| Customized break slide                    |  ✔   |        |        |
+| Credits on social media                   |  ✔   |        |        |
+| Shoutout on LinkedIn before summit        |  ✔ (<small>200 words, image</small>) | ✔ (<small>50 words</small>) |
+| Shoutout on LinkedIn after summit         |  ✔   | ✔      | ✔      |
+| Company merch                             |  ✔   | ✔      |        |
+| Table space                               |  big | small  | none   |
+| Wall or info roll-up                      |  ✔   | ✔      |        |
 <br>
 ## Other Opportunities
 

--- a/sps20/content/sponsoring/contents.lr
+++ b/sps20/content/sponsoring/contents.lr
@@ -21,15 +21,15 @@ Sponsorship benefits are outlined below. Here are some key facts:
 | Still available                           |  0   | 1      | 2      |
 | Sponsoring for both days                  |  ✔   | ✔      | ✔      |
 | Two-day tickets included                  |  5   | 3      | 2      |
-| Logo on Website                           |  ✔ (<small>big</small>) | ✔ (<small>medium</small>) | ✔ (<small>small</small>) |
+| Logo on Website                           |  ✔ <small>(big)</small> | ✔ <small>(medium)</small> | ✔ <small>(small)</small> |
 | Logo on break slides                      |  ✔   | ✔      | ✔      |
+| Shoutout on LinkedIn after summit         |  ✔   | ✔      | ✔      |
+| Shoutout on LinkedIn before summit        |  ✔ (<small>200 words, image</small>) | ✔ (<small>50 words</small>) |
+| Company merch                             |  ✔   | ✔      |        |
+| Table space                               |  ✔ <small>(big)</small> | ✔ <small>(small)</small> | |
+| Wall or info roll-up                      |  ✔   | ✔      |        |
 | Customized break slide                    |  ✔   |        |        |
 | Credits on social media                   |  ✔   |        |        |
-| Shoutout on LinkedIn before summit        |  ✔ (<small>200 words, image</small>) | ✔ (<small>50 words</small>) |
-| Shoutout on LinkedIn after summit         |  ✔   | ✔      | ✔      |
-| Company merch                             |  ✔   | ✔      |        |
-| Table space                               |  big | small  | none   |
-| Wall or info roll-up                      |  ✔   | ✔      |        |
 <br>
 ## Other Opportunities
 


### PR DESCRIPTION
A colleague mentioned that with the current order in the table it's not obvious which perks are exclusive to gold and silver sponsors. By reordering them we make it clearer:

Before:
![image](https://github.com/user-attachments/assets/9f9f0d8f-ef8b-42c7-a426-68913388591b)

After:
![image](https://github.com/user-attachments/assets/99f2cc91-2ef1-4c35-9378-e1e9ef95f92e)
