### PR TITLE
Add PyLadies Zurich lunch link for SPS26

### DIFF
--- a/sps20/content/register/_contents_2_early_bird.lr
+++ b/sps20/content/register/_contents_2_early_bird.lr
@@ -26,7 +26,7 @@ So don't miss the opportunity!
 <br>
 <a href="https://ti.to/swiss-python-summit-association/sps25" class="btn btn-primary">&nbsp;👉 Get your ticket here 👈&nbsp;</a>
 
-📢 If you are interested in joining the **Pyladies Zurich lunch** at the event, [please register here](https://docs.google.com/forms/d/e/1FAIpQLSeBs6BsUBbTT3ucAxO8ccA30ItibJIzr3rQQke4j83FYIsSXA/viewform).
+📢 If you are interested in joining the **Pyladies Zurich lunch** at the event, [please register here](https://docs.google.com/forms/d/e/1FAIpQLScPjaGw66A6by6B06qv3QuW6orvaXabdyCoXzpBnfNuLC6N-Q/viewform).
 
 The ticketing is handled by ti.to.
 

--- a/sps20/content/register/_contents_3_open.lr
+++ b/sps20/content/register/_contents_3_open.lr
@@ -20,8 +20,7 @@ Online ticket sales close at 11am CEST on Wednesday 14th October. Limited on-sit
 
 <a href="https://ti.to/swiss-python-summit-association/sps25" class="btn btn-primary">&nbsp;👉 Get your ticket here 👈&nbsp;</a>
 
-📢 If you are interested in joining the **Pyladies Zurich lunch** at the event, [please register here](https://docs.google.com/forms/d/e/
-1FAIpQLSeBs6BsUBbTT3ucAxO8ccA30ItibJIzr3rQQke4j83FYIsSXA/viewform).
+📢 If you are interested in joining the **Pyladies Zurich lunch** at the event, [please register here](https://docs.google.com/forms/d/e/1FAIpQLScPjaGw66A6by6B06qv3QuW6orvaXabdyCoXzpBnfNuLC6N-Q/viewform).
 
 <br>
 

--- a/sps20/content/register/contents.lr
+++ b/sps20/content/register/contents.lr
@@ -25,6 +25,8 @@ So don't miss the opportunity!
 <br>
 <a href="https://ti.to/swiss-python-summit-association/sps26" class="btn btn-primary">&nbsp;👉 Get your ticket here 👈&nbsp;</a>
 
+📢 If you are interested in joining the **Pyladies Zurich lunch** at the event, [please register here](https://docs.google.com/forms/d/e/1FAIpQLScPjaGw66A6by6B06qv3QuW6orvaXabdyCoXzpBnfNuLC6N-Q/viewform).
+
 The ticketing is handled by ti.to.
 
 


### PR DESCRIPTION
- register/contents.lr: add the lunch sign-up line (dropped during the SPS26 year-bump) between the ticket button and the ti.to note
- register/_contents_2_early_bird.lr, _contents_3_open.lr: point the parked lunch line at this year's Google Form (and un-split the open template's broken multi-line URL)